### PR TITLE
Modifying autorecorder to work for any% runs

### DIFF
--- a/src/Modules/EngineDemoRecorder.hpp
+++ b/src/Modules/EngineDemoRecorder.hpp
@@ -21,6 +21,7 @@ public:
     std::string currentDemo = std::string();
     bool isRecordingDemo = false;
     bool requestedStop = false;
+    int lastDemoNumber = 1;
 
 public:
     int GetTick();


### PR DESCRIPTION
Autorecorder didn't record demos during CM Wrong Warps and after Save Deletion. Tried my best to fix that but i suck lol.